### PR TITLE
avoid NPE on trailing <

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -130,6 +130,7 @@ export default function downsize(text, inputOptions, offset) {
                 // character is a word character, explamation mark or slash)
 
                 if (parseState === PARSER_UNINITIALISED &&
+                    pointer + 1 < text.length &&
                     text[pointer + 1].match(/[a-z0-9\-\_\/\!]/)) {
                     if (isAtLimit()) {
                         exit = true;

--- a/test.js
+++ b/test.js
@@ -38,6 +38,20 @@ describe("Word-wise truncation", function () {
             .should.equal("<p>this < is a > test < test</p>");
     });
 
+    it("should ignore trailing carets", function() {
+        downsize("<p>this < is a > test < test > <strong>test of word downsizing</strong> some < stuff >", {words: 5})
+            .should.equal("<p>this < is a > test < test</p>");
+
+        downsize("<p>this < is a > test < test > <strong>test of word downsizing</strong> some stuff <", {words: 5})
+            .should.equal("<p>this < is a > test < test</p>");
+
+        downsize("<p>this is < a test >", {words: 5})
+            .should.equal("<p>this is < a test ></p>");
+        
+        downsize("<p>this is < a > test <", {words: 5})
+            .should.equal("<p>this is < a > test <</p>");
+    });
+
     it("should ignore comments in markup, and carets in comments", function () {
         downsize("<p>this <!-- is a > test < test --> <strong>test of word downsizing</strong> some stuff</p>", {words: 2})
             .should.equal("<p>this <!-- is a > test < test --> <strong>test</strong></p>");
@@ -141,6 +155,8 @@ describe("Character based truncation", function () {
         downsize("<p>a</p><p>b</p><p>cdefghij</p><p>klmnop</p><p>qrs</p>", {characters: 15})
             .should.equal("<p>a</p><p>b</p><p>cdefghij</p><p>klmno</p>");
 
+        downsize("<p>ab</p><p>cd</p><p>efghi</p><p>jklmn</p><p>opqrs</p>", {characters: 15})
+            .should.equal("<p>ab</p><p>cd</p><p>efghi</p><p>jklmn</p><p>o</p>")
     });
 
     it("should await the end of the containing paragraph", function () {


### PR DESCRIPTION
without this change, when the last character in the truncated text is a less-than sign, a fatal error occurs.